### PR TITLE
allegro4: new aport

### DIFF
--- a/allegro4/APKBUILD
+++ b/allegro4/APKBUILD
@@ -1,0 +1,44 @@
+pkgname=allegro4
+pkgver=4.4.3.1
+pkgrel=0
+arch="all"
+url="https://liballeg.org"
+pkgdesc="Portable library mainly aimed at video game and multimedia programming"
+license="BSD-3-Clause"
+makedepends="
+	cmake
+	xorg-server-dev
+	mesa-dev
+	glu-dev
+	libxcursor-dev
+	libjpeg-turbo-dev
+	libwebp-dev
+	flac-dev
+	libvorbis-dev
+	libxi-dev
+	libtheora-dev
+	alsa-lib-dev
+	pulseaudio-dev
+	sdl2-dev
+	"
+options="!check"
+source="https://github.com/liballeg/allegro5/archive/$pkgver/allegro4-$pkgver.tar.gz"
+subpackages="$pkgname-dev"
+builddir="$srcdir/allegro5-$pkgver"
+
+build() {
+	cmake -B build \
+		-DCMAKE_BUILD_TYPE=None \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DALLEGRO_SDL=ON \
+		-DWANT_TESTS=ON \
+		-DWANT_DOCS=OFF
+
+	make -C build
+}
+
+package() {
+	DESTDIR="$pkgdir" make -C build install
+}
+
+sha512sums="267b2752b6f2a7e4ebf5773e2f246ae06e2c623e948dc725c816c8d4b92177aba0b0adfa736a5df8fe3ee2c27fc9b3f7a5d572541e70574fd52a323e497edec3  allegro4-4.4.3.1.tar.gz"


### PR DESCRIPTION
Some packages I'd like to build with Alpine Linux require allegro4 to work, because allegro5 (packaged in Alpine) is not backwards compatible.
https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/15709
This MR is being discussed by the moderators, so I'd thought about merging it here unofficially, as well as other packages.
I could be the maintainer of all of them and take responsibility.